### PR TITLE
Harden Vercel and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
         working-directory: groupify
 
     env:
-      NODE_ENV: test
       DB_HOST: 127.0.0.1
       DB_PORT: 3306
       DB_USER: groupify
@@ -72,3 +71,16 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Smoke test production server
+        run: |
+          npm run start > /tmp/groupify-next.log 2>&1 &
+          echo $! > /tmp/groupify-next.pid
+          for i in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:3000 > /tmp/groupify-home.html; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat /tmp/groupify-next.log
+          exit 1

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches:
+      - master
+      - main
       - nextjs
   workflow_dispatch:
 
@@ -21,6 +23,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
     steps:
       - name: Checkout
@@ -34,18 +37,27 @@ jobs:
           cache-dependency-path: groupify/package-lock.json
 
       - name: Install Vercel CLI
+        if: env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != ''
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment
-        run: vercel pull --yes --environment=${{ github.event_name == 'push' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+        if: env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != ''
+        run: vercel pull --yes --environment=${{ github.event_name == 'push' && 'production' || 'preview' }} --token=${{ env.VERCEL_TOKEN }}
 
       - name: Build with Vercel
-        run: vercel build ${{ github.event_name == 'push' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        if: env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != ''
+        run: vercel build ${{ github.event_name == 'push' && '--prod' || '' }} --token=${{ env.VERCEL_TOKEN }}
 
       - name: Deploy preview
-        if: github.event_name == 'pull_request'
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        if: github.event_name == 'pull_request' && env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != ''
+        run: vercel deploy --prebuilt --token=${{ env.VERCEL_TOKEN }}
 
       - name: Deploy production
-        if: github.event_name == 'push'
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        if: github.event_name == 'push' && env.VERCEL_TOKEN != '' && env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != ''
+        run: vercel deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }}
+
+      - name: Skip deploy when Vercel secrets are missing
+        if: env.VERCEL_TOKEN == '' || env.VERCEL_ORG_ID == '' || env.VERCEL_PROJECT_ID == ''
+        run: |
+          echo "Skipping Vercel deploy because VERCEL_TOKEN, VERCEL_ORG_ID, or VERCEL_PROJECT_ID is missing."
+          echo "Add those repository secrets to enable GitHub Actions-driven Vercel deploys."

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "npm --prefix groupify ci",
+  "buildCommand": "npm --prefix groupify run build",
+  "outputDirectory": "groupify/.next"
+}


### PR DESCRIPTION
## Summary

This follow-up makes the deployment/checks path more explicit after PR #31 exposed that Vercel was the only failing status and GitHub Actions did not give us a runtime smoke signal.

## What changed

- Adds a root-level `vercel.json` so Vercel can build correctly even when the project is configured from the repository root instead of `groupify/`.
- Runs the Vercel workflow on `master` and `main` in addition to `nextjs`.
- Makes the GitHub Actions Vercel deploy workflow skip with a clear message when required Vercel secrets are missing instead of failing opaquely.
- Adds a Linux CI smoke test that starts the built Next app with `npm run start` and curls `http://127.0.0.1:3000`.

## Why

PR #31 merged successfully but Vercel failed externally, and the checks did not clearly separate build success, runtime startup, missing Vercel secrets, and Vercel project root configuration. These changes make those failure modes much easier to diagnose.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Local production smoke test returned `HTTP 200` from `next start`